### PR TITLE
Amélioration de la logique TrafficAI

### DIFF
--- a/TrafficAI/BlockedVehicleInfo.cs
+++ b/TrafficAI/BlockedVehicleInfo.cs
@@ -13,6 +13,7 @@ namespace REALIS.TrafficAI
         public float BlockedTime { get; set; }
         public bool Honked { get; set; }
         public int BypassAttempts { get; set; }
+        public bool HasReversed { get; set; }
         public DateTime LastSeen { get; set; }
 
         public BlockedVehicleInfo(Ped driver, Vehicle vehicle)
@@ -22,6 +23,7 @@ namespace REALIS.TrafficAI
             BlockedTime = 0f;
             Honked = false;
             BypassAttempts = 0;
+            HasReversed = false;
             LastSeen = DateTime.Now;
         }
     }


### PR DESCRIPTION
## Notes
- Ajout d'une propriété `HasReversed` dans `BlockedVehicleInfo` pour suivre l'état de recul.
- Nouvelle méthode `PerformRealisticBypass` dans `TrafficIntelligenceManager` pour une manœuvre en deux étapes : reculer si possible puis dépasser sur un côté dégagé.
- Mise à jour de `UpdateVehicleIntelligently` pour utiliser cette nouvelle logique.
- Raycast modifié pour prendre en compte les piétons lors de la vérification de trajectoire.
- Nettoyage de l'état du véhicule étendu à `HasReversed`.

## Testing
- `dotnet clean`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6840ac9eb26c832a93189462bd41c34a