### PR TITLE
Amélioration du contournement TrafficAI

### DIFF
--- a/Config/TrafficAIConfig.cs
+++ b/Config/TrafficAIConfig.cs
@@ -15,10 +15,10 @@ namespace REALIS.Config
         public const float MinimumSpeed = 2.0f;
 
         /// <summary>Distance de contournement (gauche/droite)</summary>
-        public const float BypassDistance = 6.0f;
+        public const float BypassDistance = 8.0f;
 
         /// <summary>Distance vers l'avant pour le point de contournement</summary>
-        public const float ForwardOffset = 10.0f;
+        public const float ForwardOffset = 14.0f;
 
         /// <summary>Distance de recul si impossible de contourner</summary>
         public const float BackupDistance = 8.0f;

--- a/TrafficAI/BlockedVehicleInfo.cs
+++ b/TrafficAI/BlockedVehicleInfo.cs
@@ -13,6 +13,8 @@ namespace REALIS.TrafficAI
         public float BlockedTime { get; set; }
         public bool Honked { get; set; }
         public int BypassAttempts { get; set; }
+        public bool HasReversed { get; set; }
+        public DateTime LastReverseTime { get; set; }
         public DateTime LastSeen { get; set; }
 
         public BlockedVehicleInfo(Ped driver, Vehicle vehicle)
@@ -22,6 +24,8 @@ namespace REALIS.TrafficAI
             BlockedTime = 0f;
             Honked = false;
             BypassAttempts = 0;
+            HasReversed = false;
+            LastReverseTime = DateTime.MinValue;
             LastSeen = DateTime.Now;
         }
     }

--- a/TrafficAI/TrafficIntelligenceManager.cs
+++ b/TrafficAI/TrafficIntelligenceManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using REALIS.Common;
 using REALIS.Core;
+using REALIS.Config;
 
 namespace REALIS.TrafficAI
 {
@@ -187,7 +188,7 @@ namespace REALIS.TrafficAI
             // Contournement adaptatif
             if (ShouldAttemptBypass(info, blockageInfo))
             {
-                if (PerformIntelligentBypass(driver, veh, blockageInfo))
+                if (PerformRealisticBypass(info, playerVehicle, blockageInfo))
                 {
                     info.BypassAttempts++;
                     info.BlockedTime = 0f;
@@ -243,7 +244,7 @@ namespace REALIS.TrafficAI
             Vector3 start = veh.Position + Vector3.WorldUp;
             Vector3 end = start + direction * distance;
             
-            var ray = World.Raycast(start, end, IntersectFlags.Vehicles | IntersectFlags.Map, veh);
+            var ray = World.Raycast(start, end, IntersectFlags.Vehicles | IntersectFlags.Peds | IntersectFlags.Map, veh);
             return ray.DidHit;
         }
 
@@ -345,13 +346,13 @@ namespace REALIS.TrafficAI
             Vector3 basePos = veh.Position;
             Vector3 forward = veh.ForwardVector;
             Vector3 right = veh.RightVector;
-            
+
             switch (analysis.PreferredDirection)
             {
                 case BypassDirection.Left:
-                    return basePos - right * 6f + forward * 12f;
+                    return basePos - right * TrafficAIConfig.BypassDistance + forward * TrafficAIConfig.ForwardOffset;
                 case BypassDirection.Right:
-                    return basePos + right * 6f + forward * 12f;
+                    return basePos + right * TrafficAIConfig.BypassDistance + forward * TrafficAIConfig.ForwardOffset;
                 case BypassDirection.Reverse:
                     return basePos - forward * 10f;
                 default:
@@ -359,10 +360,77 @@ namespace REALIS.TrafficAI
             }
         }
 
+        /// <summary>
+        /// Contournement plus réaliste en deux étapes :
+        /// recul si possible, puis tentative de dépassement côté gauche ou droit.
+        /// </summary>
+        private bool PerformRealisticBypass(BlockedVehicleInfo info, Vehicle playerVehicle, BlockageAnalysis analysis)
+        {
+            var veh = info.Vehicle;
+            var driver = info.Driver;
+
+            if (veh == null || driver == null) return false;
+
+            try
+            {
+                if (!info.HasReversed)
+                {
+                    if (analysis.CanReverse)
+                    {
+                        Vector3 target = veh.Position - veh.ForwardVector * TrafficAIConfig.BackupDistance;
+                        Function.Call(Hash.CLEAR_PED_TASKS, driver.Handle);
+                        Function.Call(Hash.TASK_VEHICLE_DRIVE_TO_COORD,
+                            driver.Handle,
+                            veh.Handle,
+                            target.X,
+                            target.Y,
+                            target.Z,
+                            6f,
+                            0,
+                            2f);
+                        info.HasReversed = true;
+                        info.LastReverseTime = DateTime.Now;
+                        return true;
+                    }
+                    return false;
+                }
+
+                // Attendre la fin du recul
+                if ((DateTime.Now - info.LastReverseTime).TotalSeconds < 1.5f)
+                    return false;
+
+                // Après le recul, réévalue et tente un dépassement
+                var newAnalysis = AnalyzeBlockage(veh, playerVehicle);
+                if (newAnalysis.CanGoLeft)
+                {
+                    newAnalysis.PreferredDirection = BypassDirection.Left;
+                    info.HasReversed = false;
+                    return PerformIntelligentBypass(driver, veh, newAnalysis);
+                }
+                else if (newAnalysis.CanGoRight)
+                {
+                    newAnalysis.PreferredDirection = BypassDirection.Right;
+                    info.HasReversed = false;
+                    return PerformIntelligentBypass(driver, veh, newAnalysis);
+                }
+
+                info.HasReversed = false;
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"PerformRealisticBypass error: {ex.Message}");
+                info.HasReversed = false;
+                return false;
+            }
+        }
+
         private void ResetVehicleState(BlockedVehicleInfo info)
         {
             info.BlockedTime = 0f;
             info.Honked = false;
+            info.HasReversed = false;
+            info.LastReverseTime = DateTime.MinValue;
             // Les tentatives de contournement ne sont pas réinitialisées pour éviter les boucles
         }
 


### PR DESCRIPTION
## Notes
- Ajout d'un suivi `LastReverseTime` pour savoir quand un véhicule a commencé à reculer
- Attente d'1,5 s après le recul avant de tenter un dépassement pour éviter les mouvements brusques
- Utilisation des paramètres `BypassDistance` et `ForwardOffset` dans le calcul de la position de dépassement
- Augmentation des valeurs par défaut (`BypassDistance=8`, `ForwardOffset=14`) pour laisser plus d'espace au joueur

## Testing
- `dotnet clean`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6840ac9eb26c832a93189462bd41c34a
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances TrafficAI with a realistic two-step bypass process, updated configuration parameters, and improved vehicle state tracking.
> 
>   - **Behavior**:
>     - Introduces `PerformRealisticBypass()` in `TrafficIntelligenceManager.cs` for a two-step bypass process with a 1.5s delay after reversing.
>     - Updates `CalculateBypassTarget()` to use `TrafficAIConfig.BypassDistance` and `TrafficAIConfig.ForwardOffset`.
>     - Adds `HasReversed` and `LastReverseTime` to `BlockedVehicleInfo` to track reversing state.
>   - **Configuration**:
>     - Increases `BypassDistance` from 6 to 8 and `ForwardOffset` from 10 to 14 in `TrafficAIConfig.cs`.
>   - **Misc**:
>     - Modifies `IsPathBlocked()` to include pedestrians in `TrafficIntelligenceManager.cs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JeremGamingYT%2FREALIS&utm_source=github&utm_medium=referral)<sup> for ff522ddd259983c35a3ba47a82941682b0a71ca2. You can [customize](https://app.ellipsis.dev/JeremGamingYT/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->