### PR TITLE
Fix NPC bypass when siren active

### DIFF
--- a/TrafficAI/CentralizedTrafficManager.cs
+++ b/TrafficAI/CentralizedTrafficManager.cs
@@ -85,14 +85,16 @@ namespace REALIS.TrafficAI
         {
             var player = Game.Player.Character;
             if (player?.CurrentVehicle == null || !player.Exists()) return false;
-            
+
             var playerVehicle = player.CurrentVehicle;
-            if (playerVehicle.Speed < 0.3f) return false;
-            
+            bool emergencyActive = playerVehicle.Model.IsEmergencyVehicle && playerVehicle.IsSirenActive;
+
+            if (playerVehicle.Speed < 0.3f && !emergencyActive) return false;
+
             if ((DateTime.Now - _lastFullScan).TotalSeconds < PROCESSING_INTERVAL) return false;
-            
-            if (playerVehicle.Speed < 2f) return false;
-            
+
+            if (playerVehicle.Speed < 2f && !emergencyActive) return false;
+
             return true;
         }
 

--- a/TrafficAI/TrafficIntelligenceManager.cs
+++ b/TrafficAI/TrafficIntelligenceManager.cs
@@ -486,6 +486,10 @@ namespace REALIS.TrafficAI
             {
                 if (emer == null || !emer.Exists() || emer == veh) continue;
 
+                // Ignore player's emergency vehicle if it's not moving
+                if (emer == Game.Player.Character.CurrentVehicle && emer.Speed < 1f)
+                    continue;
+
                 try
                 {
                     Vector3 toVeh = veh.Position - emer.Position;


### PR DESCRIPTION
## Summary
- skip processing restrictions when player's siren is active
- ignore stationary police vehicle when evaluating emergency yield

## Testing
- `dotnet clean`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6840c7957b30832a95b8aef28aae24a8