### PR TITLE
Add dynamic NPC reactions and refine ambient behavior

### DIFF
--- a/Core/Common.cs
+++ b/Core/Common.cs
@@ -137,7 +137,13 @@ namespace REALIS.Common
     public enum AmbientInteractionType
     {
         IdleScenario,
-        Greeting
+        Greeting,
+        Flee,
+        TakeCover,
+        Cower,
+        CallPolice,
+        CallAmbulance,
+        CallFireDept
     }
 
     /// <summary>

--- a/NPC/ImmersiveNPCManager.cs
+++ b/NPC/ImmersiveNPCManager.cs
@@ -99,7 +99,7 @@ namespace REALIS.NPC
                 "WORLD_HUMAN_SMOKING",
                 "WORLD_HUMAN_STAND_MOBILE",
                 "WORLD_HUMAN_AA_SMOKE",
-                "WORLD_HUMAN_DRINKING"
+                "WORLD_HUMAN_STAND_IMPATIENT"
             };
             return scenarios[new Random().Next(scenarios.Length)];
         }

--- a/NPC/ReactiveNPCManager.cs
+++ b/NPC/ReactiveNPCManager.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GTA;
+using GTA.Native;
+using REALIS.Common;
+using REALIS.Core;
+
+namespace REALIS.NPC
+{
+    /// <summary>
+    /// Gestionnaire de réactions dynamiques des PNJ face aux situations criminelles.
+    /// </summary>
+    public class ReactiveNPCManager : Script
+    {
+        private const int UPDATE_INTERVAL = 100; // Limit processing load
+        private const float SCAN_RADIUS = 25f;
+        private const float REACTION_COOLDOWN = 20f;
+        private readonly Dictionary<int, DateTime> _lastReaction = new();
+        private readonly Random _rand = new();
+        private int _tick;
+
+        public ReactiveNPCManager()
+        {
+            Tick += OnTick;
+            Aborted += OnAborted;
+        }
+
+        private void OnTick(object sender, EventArgs e)
+        {
+            try
+            {
+                _tick++;
+                if (_tick % UPDATE_INTERVAL != 0) return;
+
+                ProcessPeds();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"ReactiveNPC tick error: {ex.Message}");
+            }
+        }
+
+        private void ProcessPeds()
+        {
+            Ped player = Game.Player.Character;
+            if (player == null || !player.Exists()) return;
+
+            Ped[] peds = World.GetNearbyPeds(player.Position, SCAN_RADIUS);
+            foreach (var ped in peds)
+            {
+                if (!IsValidPed(ped, player)) continue;
+
+                if (_lastReaction.TryGetValue(ped.Handle, out var last) &&
+                    (DateTime.Now - last).TotalSeconds < REACTION_COOLDOWN)
+                    continue;
+
+                bool playerThreat = (player.IsShooting || Function.Call<bool>(Hash.IS_PED_ARMED, player.Handle, 7)) &&
+                                     Function.Call<bool>(Hash.HAS_ENTITY_CLEAR_LOS_TO_ENTITY, ped.Handle, player.Handle, 17);
+
+                bool seesFire = World.GetNearbyPeds(ped.Position, 8f).Any(p => p != ped && p.Exists() && p.IsOnFire);
+                bool seesDead = World.GetNearbyPeds(ped.Position, 8f).Any(p => p != ped && p.Exists() && p.IsDead);
+
+                if (playerThreat)
+                {
+                    ReactToThreat(ped, player);
+                }
+                else if (seesFire)
+                {
+                    CallEmergencyServices(ped, AmbientInteractionType.CallFireDept);
+                }
+                else if (seesDead)
+                {
+                    CallEmergencyServices(ped, AmbientInteractionType.CallAmbulance);
+                    if (_rand.NextDouble() < 0.5)
+                        CallEmergencyServices(ped, AmbientInteractionType.CallPolice);
+                }
+                else
+                {
+                    continue;
+                }
+
+                _lastReaction[ped.Handle] = DateTime.Now;
+            }
+        }
+
+        private static bool IsValidPed(Ped ped, Ped player)
+        {
+            return ped != null && ped.Exists() && !ped.IsInVehicle() && ped != player && ped.IsAlive;
+        }
+
+        private void ReactToThreat(Ped ped, Ped player)
+        {
+            double r = _rand.NextDouble();
+            if (r < 0.33)
+            {
+                Function.Call(Hash.TASK_SMART_FLEE_PED, ped.Handle, player.Handle, 80f, -1, false, false);
+                FireAmbientEvent(ped, AmbientInteractionType.Flee);
+            }
+            else if (r < 0.66)
+            {
+                Function.Call(Hash.TASK_SEEK_COVER_FROM_PED, ped.Handle, player.Handle, -1, false);
+                Function.Call(Hash.TASK_START_SCENARIO_IN_PLACE, ped.Handle, "WORLD_HUMAN_STAND_MOBILE", 0, true);
+                FireAmbientEvent(ped, AmbientInteractionType.TakeCover);
+            }
+            else
+            {
+                Function.Call(Hash.TASK_COWER, ped.Handle, -1);
+                FireAmbientEvent(ped, AmbientInteractionType.Cower);
+            }
+        }
+
+        private void CallEmergencyServices(Ped ped, AmbientInteractionType service)
+        {
+            Function.Call(Hash.TASK_START_SCENARIO_IN_PLACE, ped.Handle, "WORLD_HUMAN_STAND_MOBILE", 0, true);
+            FireAmbientEvent(ped, service);
+        }
+
+        private void FireAmbientEvent(Ped ped, AmbientInteractionType type)
+        {
+            try
+            {
+                var evt = new AmbientInteractionEvent(ped, type, ped.Position);
+                CentralEventManager.Instance?.FireEvent(evt);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"ReactiveNPC event error: {ex.Message}");
+            }
+        }
+
+        private void OnAborted(object sender, EventArgs e)
+        {
+            _lastReaction.Clear();
+        }
+    }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `ReactiveNPCManager` for dynamic NPC reactions and expands `AmbientInteractionType` to enhance NPC behavior in various situations.
> 
>   - **Behavior**:
>     - Adds `ReactiveNPCManager` to handle dynamic NPC reactions to threats, fires, and dead bodies in `ReactiveNPCManager.cs`.
>     - NPCs can now flee, take cover, cower, or call emergency services based on the situation.
>     - Updates `ImmersiveNPCManager` to include `WORLD_HUMAN_STAND_IMPATIENT` scenario.
>   - **Enums**:
>     - Expands `AmbientInteractionType` in `Common.cs` to include `Flee`, `TakeCover`, `Cower`, `CallPolice`, `CallAmbulance`, and `CallFireDept`.
>   - **Events**:
>     - Uses `CentralEventManager` to fire `AmbientInteractionEvent` for new interaction types in `ReactiveNPCManager.cs` and `ImmersiveNPCManager.cs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JeremGamingYT%2FREALIS&utm_source=github&utm_medium=referral)<sup> for 62848abac936da01e344163ddfeb3d8333ea7f91. You can [customize](https://app.ellipsis.dev/JeremGamingYT/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->