### PR TITLE
Fix NPC reactions and gas station clerk check

### DIFF
--- a/Core/GasStationManager.cs
+++ b/Core/GasStationManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using GTA;
 using GTA.Math;
 using GTA.UI;
@@ -194,14 +195,26 @@ namespace REALIS.Core
 
         private void CheckClerkStatus(GasStation station)
         {
-            if (station.Clerk == null || !station.Clerk.Exists())
+            Ped? clerk = station.Clerk;
+
+            if (clerk == null || !clerk.Exists())
             {
+                Ped[] nearby = World.GetNearbyPeds(station.Entrance, 5f);
+                clerk = nearby.FirstOrDefault(p => p != Game.Player.Character && p.Exists() && p.IsAlive);
+
+                if (clerk != null)
+                {
+                    station.Clerk = clerk;
+                    station.ForceClosed = false;
+                    return;
+                }
+
                 station.ForceClosed = true;
                 return;
             }
 
-            float dist = station.Clerk.Position.DistanceTo(station.Entrance);
-            if (!station.Clerk.IsAlive || dist > 10f)
+            float dist = clerk.Position.DistanceTo(station.Entrance);
+            if (!clerk.IsAlive || dist > 10f)
             {
                 station.ForceClosed = true;
             }

--- a/NPC/ReactiveNPCManager.cs
+++ b/NPC/ReactiveNPCManager.cs
@@ -55,7 +55,9 @@ namespace REALIS.NPC
                     (DateTime.Now - last).TotalSeconds < REACTION_COOLDOWN)
                     continue;
 
-                bool playerThreat = (player.IsShooting || Function.Call<bool>(Hash.IS_PED_ARMED, player.Handle, 7)) &&
+                bool aiming = Function.Call<bool>(Hash.IS_PLAYER_FREE_AIMING, Game.Player.Handle);
+                bool weaponDrawn = player.Weapons.Current.Hash != WeaponHash.Unarmed;
+                bool playerThreat = (player.IsShooting || (weaponDrawn && aiming)) &&
                                      Function.Call<bool>(Hash.HAS_ENTITY_CLEAR_LOS_TO_ENTITY, ped.Handle, player.Handle, 17);
 
                 bool seesFire = World.GetNearbyPeds(ped.Position, 8f).Any(p => p != ped && p.Exists() && p.IsOnFire);


### PR DESCRIPTION
## Summary
- refine threat detection in `ReactiveNPCManager` to avoid false panic
- detect replacement clerks for gas stations instead of forcing closure

## Testing
- `dotnet clean`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68410faf13fc832ab45db8a66af21c09
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves NPC threat detection and gas station clerk management to prevent false panic and unnecessary closures.
> 
>   - **Gas Station Management**:
>     - In `GasStationManager.cs`, `CheckClerkStatus()` now assigns a nearby pedestrian as a clerk if the original clerk is missing, preventing forced closure.
>     - Updates to `CheckClerkStatus()` ensure the station is only forced closed if no replacement clerk is found or if the clerk is too far or dead.
>   - **NPC Threat Detection**:
>     - In `ReactiveNPCManager.cs`, refines threat detection by checking if the player is aiming and has a weapon drawn, reducing false panic.
>     - Updates `ProcessPeds()` to use new threat detection logic, ensuring NPCs react appropriately to player actions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JeremGamingYT%2FREALIS&utm_source=github&utm_medium=referral)<sup> for 7abd70dfbafae7df171c476e404ffaf1e6ca5570. You can [customize](https://app.ellipsis.dev/JeremGamingYT/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->