### PR TITLE
Fix escort handcuff check

### DIFF
--- a/Core/PoliceSystem.cs
+++ b/Core/PoliceSystem.cs
@@ -136,7 +136,9 @@ namespace REALIS.Core
                 Game.DisableControlThisFrame(Control.Jump);
             }
 
-            if (!Function.Call<bool>(Hash.IS_PED_RUNNING_ARREST_TASK, _arrestingOfficer))
+            // attendre que le joueur soit menotté avant de poursuivre l'escorte
+            if (!Function.Call<bool>(Hash.IS_PED_RUNNING_ARREST_TASK, _arrestingOfficer) &&
+                Function.Call<bool>(Hash.IS_PED_CUFFED, player))
             {
                 if (_policeVehicle == null || !_policeVehicle.Exists())
                 {


### PR DESCRIPTION
## Summary
- ensure the officer waits until the player is cuffed before escorting to the police car

## Testing
- `dotnet clean`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68433ce5a3fc832a9c938cea385d3c21
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add check in `UpdateEscort()` in `PoliceSystem.cs` to ensure player is cuffed before escorting.
> 
>   - **Behavior**:
>     - In `UpdateEscort()` in `PoliceSystem.cs`, added a check to ensure the player is cuffed (`IS_PED_CUFFED`) before continuing escort.
>   - **Misc**:
>     - Added a comment in `UpdateEscort()` to explain the new cuff check logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JeremGamingYT%2FREALIS&utm_source=github&utm_medium=referral)<sup> for 14888c320db3e6f27393acba3ce45e1aa11aa65f. You can [customize](https://app.ellipsis.dev/JeremGamingYT/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->